### PR TITLE
Fix markdown formatting for headers in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,11 +73,11 @@ to keep this project open source, hence this new method.
 
 Please visit this [page](https://feednix-jarkore.rhcloud.com) for details.
 
-##Changelog
+## Changelog
 
 **The follwoing only lists major updates. For everything in between please see the ChangeLog**
 
-###v0.9
+### v0.9
 Once again many thanks to [lejenome](https://github.com/lejenome) for the following:
 
 * fix panels array length
@@ -89,7 +89,7 @@ Once again many thanks to [lejenome](https://github.com/lejenome) for the follow
 * replace tabs with 8 spaces
 * add .gitignore file 
 
-###v0.8
+### v0.8
 
 Many thanks to [lejenome](https://github.com/lejenome) for the following: 
 


### PR DESCRIPTION
Markdown headers require a space after the hashes to be properly parsed. This commit will add those spaces. 

Before:

![image](https://user-images.githubusercontent.com/24862378/34225678-29c13420-e5bf-11e7-93d9-b6d505af8399.png)

After:

![image](https://user-images.githubusercontent.com/24862378/34225686-2eb0dabc-e5bf-11e7-8686-ccb3a704e93c.png)
